### PR TITLE
Feat/spend strategies

### DIFF
--- a/lib/screens/spend/custom_fee_screen.dart
+++ b/lib/screens/spend/custom_fee_screen.dart
@@ -64,9 +64,11 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
         });
       }
 
-      // Propose a selection for the currently selected rate
+      // Propose a selection for the currently selected rate; the user
+      // explicitly chose this rate, so honor it rather than going changeless
       final selection = await walletState.proposeCoinSelection(
-          widget.recipient, _selectedFeeRate);
+          widget.recipient, _selectedFeeRate,
+          forceFeeRate: true);
 
       if (mounted) {
         setState(() {

--- a/lib/screens/spend/custom_fee_screen.dart
+++ b/lib/screens/spend/custom_fee_screen.dart
@@ -4,7 +4,7 @@ import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/models/bip353_address.dart';
 import 'package:danawallet/extensions/api_amount.dart';
 import 'package:danawallet/data/enums/selected_fee.dart';
-import 'package:danawallet/generated/rust/api/structs/amount.dart';
+import 'package:danawallet/generated/rust/api/structs/input_selection.dart';
 import 'package:danawallet/generated/rust/api/structs/recipient.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/screens/spend/ready_to_send.dart';
@@ -32,7 +32,7 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
 
   int _selectedFeeRate = _minFeeRate; // Default to 1 sat/vB
   double _sliderValue = 0.0; // slider position in [0, 1]
-  final Map<int, Amount> _feeAmounts = {};
+  InputSelection? _selection;
   bool _isLoadingFees = true;
   String? _errorMessage;
 
@@ -64,30 +64,24 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
         });
       }
 
-      // Compute fee for the currently selected rate
-      final feeEstimationTx = await walletState.createUnsignedTxToThisRecipient(
+      // Propose a selection for the currently selected rate
+      final selection = await walletState.proposeCoinSelection(
           widget.recipient, _selectedFeeRate);
-      BigInt inputSum = BigInt.from(0);
-      for (var (_, utxo) in feeEstimationTx.selectedUtxos) {
-        inputSum += utxo.value.field0;
-      }
-      BigInt outputSum = BigInt.from(0);
-      for (var recipient in feeEstimationTx.recipients) {
-        outputSum += recipient.amount.field0;
-      }
-      _feeAmounts[_selectedFeeRate] = Amount(field0: inputSum - outputSum);
 
       if (mounted) {
         setState(() {
+          _selection = selection;
           _isLoadingFees = false;
         });
       }
     } catch (e) {
       if (mounted) {
         setState(() {
+          _selection = null;
           _isLoadingFees = false;
           // Check if it's an insufficient funds error
-          if (e.toString().contains('Insufficient funds')) {
+          if (e.toString().contains('Insufficient funds') ||
+              e.toString().contains('funds available')) {
             _errorMessage =
                 'Fee too high - exceeds available funds. Try a lower fee rate.';
           } else {
@@ -99,16 +93,19 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
   }
 
   Future<void> onContinue() async {
-    final walletState = Provider.of<WalletState>(context, listen: false);
-    final changeCode = walletState.changePaymentCode;
+    final selection = _selection;
+    if (selection == null) return;
 
-    final unsignedTx = await walletState.createUnsignedTxToThisRecipient(
-        widget.recipient, _selectedFeeRate);
+    final walletState = Provider.of<WalletState>(context, listen: false);
+
+    // build the transaction from the selection the fee was displayed for
+    final unsignedTx = await walletState.createUnsignedTxFromSelection(
+        widget.recipient, selection);
 
     // update the send amount to the actual sent amount (can be different e.g. dust)
     final updatedRecipient = Recipient(
       paymentCode: widget.recipient.paymentCode,
-      amount: unsignedTx.getSendAmount(changeCode: changeCode),
+      amount: unsignedTx.getSendAmount(),
     );
 
     if (mounted) {
@@ -259,7 +256,7 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
                           Text(
                             _isLoadingFees
                                 ? 'Loading...'
-                                : _feeAmounts[_selectedFeeRate]?.display(
+                                : _selection?.fee.display(
                                         displayPreference.amountDisplayUnit) ??
                                     'N/A',
                             style: BitcoinTextStyle.body4(Bitcoin.black),
@@ -277,8 +274,7 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
                           Text(
                             _isLoadingFees
                                 ? 'Loading...'
-                                : exchangeRate.displayFiat(
-                                    _feeAmounts[_selectedFeeRate]!,
+                                : exchangeRate.displayFiat(_selection!.fee,
                                     displayPreference.fiatCurrency),
                             style: BitcoinTextStyle.body5(Bitcoin.neutral7),
                           ),

--- a/lib/screens/spend/fee_selection.dart
+++ b/lib/screens/spend/fee_selection.dart
@@ -4,7 +4,7 @@ import 'package:danawallet/data/models/bip353_address.dart';
 import 'package:danawallet/data/models/recommended_fee_model.dart';
 import 'package:danawallet/extensions/api_amount.dart';
 import 'package:danawallet/data/enums/selected_fee.dart';
-import 'package:danawallet/generated/rust/api/structs/amount.dart';
+import 'package:danawallet/generated/rust/api/structs/input_selection.dart';
 import 'package:danawallet/generated/rust/api/structs/recipient.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/screens/spend/ready_to_send.dart';
@@ -33,7 +33,7 @@ class FeeSelectionScreen extends StatefulWidget {
 class FeeSelectionScreenState extends State<FeeSelectionScreen> {
   RecommendedFeeResponse? _currentFeeRates;
   SelectedFee _selected = SelectedFee.normal;
-  final Map<SelectedFee, Amount> _feeAmounts = {};
+  final Map<SelectedFee, InputSelection> _selections = {};
 
   @override
   void initState() {
@@ -54,17 +54,8 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
       SelectedFee.slow
     ]) {
       final feerate = fee.getFeeRate(currentFeeRates);
-      final feeEstimationTx = await walletState.createUnsignedTxToThisRecipient(
-          widget.recipient, feerate);
-      BigInt inputSum = BigInt.from(0);
-      for (var (_, utxo) in feeEstimationTx.selectedUtxos) {
-        inputSum += utxo.value.field0;
-      }
-      BigInt outputSum = BigInt.from(0);
-      for (var recipient in feeEstimationTx.recipients) {
-        outputSum += recipient.amount.field0;
-      }
-      _feeAmounts[fee] = Amount(field0: inputSum - outputSum);
+      _selections[fee] =
+          await walletState.proposeCoinSelection(widget.recipient, feerate);
     }
 
     setState(() {
@@ -74,17 +65,17 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
 
   Future<void> onContinue() async {
     final walletState = Provider.of<WalletState>(context, listen: false);
-    final changeCode = walletState.changePaymentCode;
 
-    final feerate = _selected.getFeeRate(_currentFeeRates!);
+    // build the transaction from the selection the fee was displayed for
+    final selection = _selections[_selected]!;
 
-    final unsignedTx = await walletState.createUnsignedTxToThisRecipient(
-        widget.recipient, feerate);
+    final unsignedTx = await walletState.createUnsignedTxFromSelection(
+        widget.recipient, selection);
 
     // update the send amount to the actual sent amount (can be different e.g. dust)
     final updatedRecipient = Recipient(
       paymentCode: widget.recipient.paymentCode,
-      amount: unsignedTx.getSendAmount(changeCode: changeCode),
+      amount: unsignedTx.getSendAmount(),
     );
 
     if (mounted) {
@@ -114,7 +105,7 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
           subtitleBtc = 'Loading...';
           subtitleFiat = 'Loading...';
         } else {
-          final estimatedFee = _feeAmounts[fee];
+          final estimatedFee = _selections[fee]?.fee;
           if (estimatedFee == null) {
             throw Exception('Fee amount not computed for $fee');
           }

--- a/lib/screens/spend/ready_to_send.dart
+++ b/lib/screens/spend/ready_to_send.dart
@@ -99,6 +99,14 @@ class ReadyToSendScreenState extends State<ReadyToSendScreen> {
     String displayEstimatedFee =
         widget.unsignedTx.getFeeAmount().display(bitcoinUnit);
 
+    // show the actual fee rate, which may exceed the requested one
+    // (e.g. when a changeless selection was used)
+    final displayFeeRate = widget.unsignedTx.actualFeeRate
+        .toStringAsFixed(2)
+        .replaceAll(RegExp(r'0+$'), '')
+        .replaceAll(RegExp(r'\.$'), '');
+    displayEstimatedFee = '$displayEstimatedFee ($displayFeeRate sat/vB)';
+
     return ScreenSkeleton(
         showBackButton: true,
         title: 'Ready to send?',

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -21,31 +21,9 @@ import 'package:danawallet/repositories/transactions_repository.dart';
 import 'package:danawallet/repositories/wallet_repository.dart';
 import 'package:danawallet/services/bip353_resolver.dart';
 import 'package:danawallet/services/dana_address_service.dart';
+import 'package:danawallet/utils/coin_selection.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
-
-/// Pick the preferred selection from the candidates produced by the
-/// coin-selection strategies: a changeless transaction first (no change
-/// output to fingerprint), then the lowest fee, then the exact-rate
-/// selection, then the greedy fallback.
-InputSelection pickDefaultSelection(List<InputSelection> selections) {
-  for (final preferred in const [
-    CoinSelectionStrategy.changeless,
-    CoinSelectionStrategy.lowestFee,
-    CoinSelectionStrategy.feeRateCap,
-    CoinSelectionStrategy.greedy,
-  ]) {
-    for (final selection in selections) {
-      if (selection.strategy == preferred) {
-        return selection;
-      }
-    }
-  }
-  if (selections.isEmpty) {
-    throw Exception('No coin selection strategy succeeded');
-  }
-  return selections.first;
-}
 
 class WalletState extends ChangeNotifier {
   final walletRepository = WalletRepository.instance;
@@ -278,8 +256,12 @@ class WalletState extends ChangeNotifier {
 
   /// Propose a coin selection for a payment to [recipient] at [feerate]
   /// (sat/vB), using the default coin-selection policy.
-  Future<InputSelection> proposeCoinSelection(
-      Recipient recipient, int feerate) async {
+  ///
+  /// When [forceFeeRate] is set (the user explicitly chose a fee rate), the
+  /// selection honoring the requested rate is preferred over a changeless
+  /// one (which may exceed it).
+  Future<InputSelection> proposeCoinSelection(Recipient recipient, int feerate,
+      {bool forceFeeRate = false}) async {
     if (_isDrainPayment(recipient)) {
       return selectUtxosToDrain(
           ownedOutputs: unspentOutputs,
@@ -292,7 +274,7 @@ class WalletState extends ChangeNotifier {
         recipients: [recipient],
         nChangeOutputs: BigInt.one,
         feerate: feerate.toDouble());
-    return pickDefaultSelection(selections);
+    return pickDefaultSelection(selections, forceFeeRate: forceFeeRate);
   }
 
   /// Build the unsigned transaction for a previously chosen [selection]

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -4,6 +4,7 @@ import 'package:danawallet/data/models/bip353_address.dart';
 import 'package:danawallet/extensions/date_time.dart';
 import 'package:danawallet/extensions/network.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
+import 'package:danawallet/generated/rust/api/structs/input_selection.dart';
 import 'package:danawallet/generated/rust/api/structs/outpoint.dart';
 import 'package:danawallet/generated/rust/api/structs/owned_output.dart';
 import 'package:danawallet/generated/rust/api/structs/recipient.dart';
@@ -11,6 +12,7 @@ import 'package:danawallet/generated/rust/api/structs/unsigned_transaction.dart'
 import 'package:danawallet/data/models/recorded_transaction.dart';
 import 'package:danawallet/generated/rust/api/structs/network.dart';
 import 'package:danawallet/generated/rust/api/wallet.dart';
+import 'package:danawallet/generated/rust/api/wallet/coin_selection.dart';
 import 'package:danawallet/generated/rust/api/wallet/setup.dart';
 import 'package:danawallet/repositories/mempool_api_repository.dart';
 import 'package:danawallet/repositories/owned_outputs_repository.dart';
@@ -21,6 +23,29 @@ import 'package:danawallet/services/bip353_resolver.dart';
 import 'package:danawallet/services/dana_address_service.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
+
+/// Pick the preferred selection from the candidates produced by the
+/// coin-selection strategies: a changeless transaction first (no change
+/// output to fingerprint), then the lowest fee, then the exact-rate
+/// selection, then the greedy fallback.
+InputSelection pickDefaultSelection(List<InputSelection> selections) {
+  for (final preferred in const [
+    CoinSelectionStrategy.changeless,
+    CoinSelectionStrategy.lowestFee,
+    CoinSelectionStrategy.feeRateCap,
+    CoinSelectionStrategy.greedy,
+  ]) {
+    for (final selection in selections) {
+      if (selection.strategy == preferred) {
+        return selection;
+      }
+    }
+  }
+  if (selections.isEmpty) {
+    throw Exception('No coin selection strategy succeeded');
+  }
+  return selections.first;
+}
 
 class WalletState extends ChangeNotifier {
   final walletRepository = WalletRepository.instance;
@@ -246,25 +271,55 @@ class WalletState extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<SilentPaymentUnsignedTransaction> createUnsignedTxToThisRecipient(
+  // A payment is treated as a drain when it (nearly) empties the wallet
+  bool _isDrainPayment(Recipient recipient) {
+    return recipient.amount.field0 >= amount.field0 - BigInt.from(546);
+  }
+
+  /// Propose a coin selection for a payment to [recipient] at [feerate]
+  /// (sat/vB), using the default coin-selection policy.
+  Future<InputSelection> proposeCoinSelection(
       Recipient recipient, int feerate) async {
+    if (_isDrainPayment(recipient)) {
+      return selectUtxosToDrain(
+          ownedOutputs: unspentOutputs,
+          recipientAddress: recipient.paymentCode,
+          feerate: feerate.toDouble());
+    }
+
+    final selections = await selectUtxosToSpend(
+        ownedOutputs: unspentOutputs,
+        recipients: [recipient],
+        nChangeOutputs: BigInt.one,
+        feerate: feerate.toDouble());
+    return pickDefaultSelection(selections);
+  }
+
+  /// Build the unsigned transaction for a previously chosen [selection]
+  /// (see [proposeCoinSelection]), so the transaction signed is exactly the
+  /// one whose fee was presented to the user.
+  Future<SilentPaymentUnsignedTransaction> createUnsignedTxFromSelection(
+      Recipient recipient, InputSelection selection) async {
     final wallet = await getWalletFromSecureStorage();
 
-    if (recipient.amount.field0 < amount.field0 - BigInt.from(546)) {
-      return wallet.createNewTransaction(
+    if (_isDrainPayment(recipient)) {
+      // The drain amount is only known after fee estimation: it is whatever
+      // is left after paying the fee for spending all UTXOs.
+      final drainRecipient =
+          Recipient(paymentCode: recipient.paymentCode, amount: selection.sent);
+
+      return wallet.createTransactionFromSelection(
           ownedOutputs: unspentOutputs,
-          apiRecipients: [
-            recipient,
-          ],
-          feerate: feerate.toDouble(),
-          network: network);
-    } else {
-      return wallet.createDrainTransaction(
-          ownedOutputs: unspentOutputs,
-          wipeAddress: recipient.paymentCode,
-          feerate: feerate.toDouble(),
+          apiRecipients: [drainRecipient],
+          selection: selection,
           network: network);
     }
+
+    return wallet.createTransactionFromSelection(
+        ownedOutputs: unspentOutputs,
+        apiRecipients: [recipient],
+        selection: selection,
+        network: network);
   }
 
   Future<String> signAndBroadcastUnsignedTx(

--- a/lib/utils/coin_selection.dart
+++ b/lib/utils/coin_selection.dart
@@ -1,0 +1,40 @@
+import 'package:danawallet/generated/rust/api/structs/input_selection.dart';
+
+/// Pick the preferred selection from the candidates produced by the
+/// coin-selection strategies.
+///
+/// By default a changeless transaction is preferred (no change output to
+/// fingerprint), then the lowest fee, then the exact-rate (fee rate cap)
+/// selection, then the greedy fallback.
+///
+/// When [forceFeeRate] is set (the user explicitly chose a fee rate), the
+/// exact-rate selection — which spdk only produces when the requested rate
+/// can be honored — is preferred, then lowest fee, then greedy; a
+/// changeless selection comes last, as it may exceed the requested rate.
+InputSelection pickDefaultSelection(List<InputSelection> selections,
+    {bool forceFeeRate = false}) {
+  final preference = forceFeeRate
+      ? const [
+          CoinSelectionStrategy.feeRateCap,
+          CoinSelectionStrategy.lowestFee,
+          CoinSelectionStrategy.greedy,
+          CoinSelectionStrategy.changeless,
+        ]
+      : const [
+          CoinSelectionStrategy.changeless,
+          CoinSelectionStrategy.lowestFee,
+          CoinSelectionStrategy.feeRateCap,
+          CoinSelectionStrategy.greedy,
+        ];
+  for (final preferred in preference) {
+    for (final selection in selections) {
+      if (selection.strategy == preferred) {
+        return selection;
+      }
+    }
+  }
+  if (selections.isEmpty) {
+    throw Exception('No coin selection strategy succeeded');
+  }
+  return selections.first;
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "backend-blindbit-v1"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#8dbf11b7c63a995ca34f699fd5056a587a6c7581"
+source = "git+https://github.com/cygnet3/spdk?rev=83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28#83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1988,7 +1988,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "silentpayments"
 version = "0.6.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#8dbf11b7c63a995ca34f699fd5056a587a6c7581"
+source = "git+https://github.com/cygnet3/spdk?rev=83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28#83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin_hashes 0.13.0",
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "spdk-core"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#8dbf11b7c63a995ca34f699fd5056a587a6c7581"
+source = "git+https://github.com/cygnet3/spdk?rev=83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28#83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "spdk-wallet"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#8dbf11b7c63a995ca34f699fd5056a587a6c7581"
+source = "git+https://github.com/cygnet3/spdk?rev=83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28#83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28"
 dependencies = [
  "anyhow",
  "backend-blindbit-v1",
@@ -2068,6 +2068,7 @@ dependencies = [
  "bitcoin 0.32.8",
  "futures",
  "log",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "silentpayments",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 flutter_rust_bridge = "=2.12.0"
-spdk-wallet = { git = "https://github.com/cygnet3/spdk", branch = "master" }
+spdk-wallet = { git = "https://github.com/cygnet3/spdk", rev = "83fc3cdabbfca366ad5a405e4d3fa5d1a0201f28" }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/rust/src/api/structs/input_selection.rs
+++ b/rust/src/api/structs/input_selection.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use spdk_wallet::client::FeeRate;
+
+use crate::api::structs::amount::Amount;
+use crate::api::structs::outpoint::OutPoint;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoinSelectionStrategy {
+    Changeless,
+    LowestFee,
+    FeeRateCap,
+    Greedy,
+    Drain,
+}
+
+impl From<spdk_wallet::client::Strategy> for CoinSelectionStrategy {
+    fn from(value: spdk_wallet::client::Strategy) -> Self {
+        match value {
+            spdk_wallet::client::Strategy::Changeless => Self::Changeless,
+            spdk_wallet::client::Strategy::LowestFee => Self::LowestFee,
+            spdk_wallet::client::Strategy::FeeRateCap => Self::FeeRateCap,
+            spdk_wallet::client::Strategy::Greedy => Self::Greedy,
+            spdk_wallet::client::Strategy::Drain => Self::Drain,
+        }
+    }
+}
+
+impl From<CoinSelectionStrategy> for spdk_wallet::client::Strategy {
+    fn from(value: CoinSelectionStrategy) -> Self {
+        match value {
+            CoinSelectionStrategy::Changeless => Self::Changeless,
+            CoinSelectionStrategy::LowestFee => Self::LowestFee,
+            CoinSelectionStrategy::FeeRateCap => Self::FeeRateCap,
+            CoinSelectionStrategy::Greedy => Self::Greedy,
+            CoinSelectionStrategy::Drain => Self::Drain,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InputSelection {
+    pub selected_utxos: Vec<OutPoint>,
+    pub sent: Amount,
+    pub n_sent_outputs: usize,
+    pub change: Amount,
+    pub n_change_outputs: usize,
+    pub fee: Amount,
+    /// Fee rate in satoshis per virtual byte.
+    pub actual_fee_rate: f32,
+    pub strategy: CoinSelectionStrategy,
+}
+
+impl From<spdk_wallet::client::InputSelection> for InputSelection {
+    fn from(value: spdk_wallet::client::InputSelection) -> Self {
+        Self {
+            selected_utxos: value
+                .selected_utxos
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            sent: value.sent.into(),
+            n_sent_outputs: value.n_sent_outputs,
+            change: value.change.into(),
+            n_change_outputs: value.n_change_outputs,
+            fee: value.fee.into(),
+            actual_fee_rate: value.actual_fee_rate.as_sat_vb(),
+            strategy: value.strategy.into(),
+        }
+    }
+}
+
+impl From<InputSelection> for spdk_wallet::client::InputSelection {
+    fn from(value: InputSelection) -> Self {
+        Self {
+            selected_utxos: value
+                .selected_utxos
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            sent: value.sent.into(),
+            n_sent_outputs: value.n_sent_outputs,
+            change: value.change.into(),
+            n_change_outputs: value.n_change_outputs,
+            fee: value.fee.into(),
+            actual_fee_rate: FeeRate::from_sat_per_vb(value.actual_fee_rate),
+            strategy: value.strategy.into(),
+        }
+    }
+}

--- a/rust/src/api/structs/mod.rs
+++ b/rust/src/api/structs/mod.rs
@@ -1,5 +1,6 @@
 pub mod amount;
 pub mod discovered_output;
+pub mod input_selection;
 pub mod network;
 pub mod outpoint;
 pub mod owned_output;

--- a/rust/src/api/structs/owned_output.rs
+++ b/rust/src/api/structs/owned_output.rs
@@ -3,6 +3,10 @@ use flutter_rust_bridge::frb;
 use crate::api::structs::amount::Amount;
 use crate::api::structs::outpoint::OutPoint;
 
+use anyhow::Result;
+use spdk_wallet::bitcoin::secp256k1::Scalar;
+use spdk_wallet::bitcoin::ScriptBuf;
+
 #[derive(Debug, Clone)]
 #[frb]
 pub struct OwnedOutput {
@@ -11,4 +15,28 @@ pub struct OwnedOutput {
     pub amount: Amount,
     pub script: Vec<u8>,
     pub label: Option<[u8; 32]>,
+}
+
+/// The wallet's native UTXO representation, as used by the coin-selection
+/// and transaction-construction functions.
+pub(crate) type WalletUtxo = (
+    spdk_wallet::bitcoin::OutPoint,
+    spdk_wallet::updater::DiscoveredOutput,
+);
+
+impl OwnedOutput {
+    /// Convert to the wallet's native UTXO representation.
+    pub(crate) fn try_into_utxo(self) -> Result<WalletUtxo> {
+        let label = match self.label {
+            Some(l) => Some(Scalar::from_be_bytes(l)?.into()),
+            None => None,
+        };
+        let output = spdk_wallet::updater::DiscoveredOutput {
+            tweak: Scalar::from_be_bytes(self.tweak)?,
+            value: self.amount.into(),
+            script_pubkey: ScriptBuf::from_bytes(self.script),
+            label,
+        };
+        Ok((self.outpoint.into(), output))
+    }
 }

--- a/rust/src/api/structs/unsigned_transaction.rs
+++ b/rust/src/api/structs/unsigned_transaction.rs
@@ -5,11 +5,13 @@ use spdk_wallet::{
         hex::{DisplayHex, FromHex},
         Network,
     },
+    client::FeeRate,
     silentpayments::utils::sending::PartialSecret,
 };
 
 use crate::api::structs::amount::Amount;
 use crate::api::structs::discovered_output::DiscoveredOutput;
+use crate::api::structs::input_selection::CoinSelectionStrategy;
 use crate::api::structs::recipient::Recipient;
 
 pub struct SilentPaymentUnsignedTransaction {
@@ -18,6 +20,14 @@ pub struct SilentPaymentUnsignedTransaction {
     pub partial_secret: [u8; 32],
     pub unsigned_tx: Option<String>,
     pub network: String,
+    /// Wallet change amount (zero for drain / changeless selections).
+    pub change: Amount,
+    /// Indices into `recipients` that are change outputs.
+    pub change_indexes: Vec<u32>,
+    pub fee: Amount,
+    /// Fee rate in satoshis per virtual byte.
+    pub actual_fee_rate: f32,
+    pub strategy: CoinSelectionStrategy,
 }
 
 impl From<spdk_wallet::client::SilentPaymentUnsignedTransaction>
@@ -36,6 +46,11 @@ impl From<spdk_wallet::client::SilentPaymentUnsignedTransaction>
                 .unsigned_tx
                 .map(|tx| serialize(&tx).to_lower_hex_string()),
             network: value.network.to_core_arg().to_string(),
+            change: value.change.into(),
+            change_indexes: value.change_indexes.into_iter().map(|i| i as u32).collect(),
+            fee: value.fee.into(),
+            actual_fee_rate: value.actual_fee_rate.as_sat_vb(),
+            strategy: value.strategy.into(),
         }
     }
 }
@@ -60,59 +75,46 @@ impl From<SilentPaymentUnsignedTransaction>
                 .unsigned_tx
                 .map(|tx| deserialize(&Vec::from_hex(&tx).unwrap()).unwrap()),
             network: Network::from_core_arg(&value.network).unwrap(),
+            change: value.change.into(),
+            change_indexes: value.change_indexes.into_iter().map(|i| i as usize).collect(),
+            fee: value.fee.into(),
+            actual_fee_rate: FeeRate::from_sat_per_vb(value.actual_fee_rate),
+            strategy: value.strategy.into(),
         }
     }
 }
 
 impl SilentPaymentUnsignedTransaction {
     #[frb(sync)]
-    pub fn get_send_amount(&self, change_code: String) -> Amount {
+    pub fn get_send_amount(&self) -> Amount {
         let amount = self
             .recipients
             .iter()
-            .filter_map(|r| {
-                if r.payment_code != change_code {
-                    Some(r.amount.0)
-                } else {
-                    None
-                }
-            })
+            .enumerate()
+            .filter(|(i, _)| !self.change_indexes.contains(&(*i as u32)))
+            .map(|(_, r)| r.amount.0)
             .sum();
 
         Amount(amount)
     }
 
     #[frb(sync)]
-    pub fn get_change_amount(&self, change_code: String) -> Amount {
-        let amount = self
-            .recipients
-            .iter()
-            .filter_map(|r| {
-                if r.payment_code == change_code {
-                    Some(r.amount.0)
-                } else {
-                    None
-                }
-            })
-            .sum();
-        Amount(amount)
+    pub fn get_change_amount(&self) -> Amount {
+        self.change.clone()
     }
 
     #[frb(sync)]
     pub fn get_fee_amount(&self) -> Amount {
-        let input_sum: u64 = self.selected_utxos.iter().map(|(_, o)| o.value.0).sum();
-
-        let output_sum: u64 = self.recipients.iter().map(|r| r.amount.0).sum();
-
-        Amount(input_sum - output_sum)
+        self.fee.clone()
     }
 
     #[frb(sync)]
-    pub fn get_recipients(&self, change_code: String) -> Vec<Recipient> {
+    pub fn get_recipients(&self) -> Vec<Recipient> {
         self.recipients
             .iter()
-            .filter(|r| r.payment_code != change_code)
-            .cloned()
+            .enumerate()
+            .filter(|(i, _)| !self.change_indexes.contains(&(*i as u32)))
+            .map(|(_, r)| r.clone())
             .collect()
     }
 }

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -2,6 +2,7 @@ mod info;
 pub mod setup;
 mod sync;
 mod transaction;
+pub mod coin_selection;
 
 use crate::{api::structs::network::Network, wallet::WalletFingerprint};
 use anyhow::Result;

--- a/rust/src/api/wallet/coin_selection.rs
+++ b/rust/src/api/wallet/coin_selection.rs
@@ -1,0 +1,70 @@
+use crate::api::structs::{
+    input_selection::InputSelection, owned_output::OwnedOutput, recipient::Recipient,
+};
+
+use anyhow::Result;
+use spdk_wallet::client::{
+    propose_coin_selections, propose_drain_selection, FeeRate, RecipientAddress, Strategy,
+};
+
+/// Pick the preferred selection out of the candidates produced by the
+/// coin-selection strategies: a changeless transaction first (no change
+/// output to fingerprint), then the lowest fee, then the greedy fallback.
+pub(crate) fn pick_default_selection(
+    mut selections: Vec<spdk_wallet::client::InputSelection>,
+) -> Result<spdk_wallet::client::InputSelection> {
+    for preferred in [Strategy::Changeless, Strategy::LowestFee, Strategy::Greedy] {
+        if let Some(pos) = selections.iter().position(|s| s.strategy == preferred) {
+            return Ok(selections.swap_remove(pos));
+        }
+    }
+    selections
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::Error::msg("no successful coin selection"))
+}
+
+pub fn select_utxos_to_spend(
+    owned_outputs: Vec<OwnedOutput>,
+    recipients: Vec<Recipient>,
+    n_change_outputs: usize,
+    feerate: f32,
+) -> Result<Vec<InputSelection>> {
+    let available_utxos = owned_outputs
+        .into_iter()
+        .map(|o| o.try_into_utxo())
+        .collect::<Result<Vec<_>>>()?;
+    let recipients = recipients
+        .into_iter()
+        .map(|r| r.try_into())
+        .collect::<Result<Vec<spdk_wallet::client::Recipient>>>()?;
+
+    let selections = propose_coin_selections(
+        &available_utxos,
+        &recipients,
+        FeeRate::from_sat_per_vb(feerate),
+        n_change_outputs,
+    )?;
+
+    Ok(selections.into_iter().map(Into::into).collect())
+}
+
+pub fn select_utxos_to_drain(
+    owned_outputs: Vec<OwnedOutput>,
+    recipient_address: String,
+    feerate: f32,
+) -> Result<InputSelection> {
+    let available_utxos = owned_outputs
+        .into_iter()
+        .map(|o| o.try_into_utxo())
+        .collect::<Result<Vec<_>>>()?;
+    let recipient_address = RecipientAddress::try_from(recipient_address)?;
+
+    let selection = propose_drain_selection(
+        &available_utxos,
+        &recipient_address,
+        FeeRate::from_sat_per_vb(feerate),
+    )?;
+
+    Ok(selection.into())
+}

--- a/rust/src/api/wallet/coin_selection.rs
+++ b/rust/src/api/wallet/coin_selection.rs
@@ -4,25 +4,8 @@ use crate::api::structs::{
 
 use anyhow::Result;
 use spdk_wallet::client::{
-    propose_coin_selections, propose_drain_selection, FeeRate, RecipientAddress, Strategy,
+    propose_coin_selections, propose_drain_selection, FeeRate, RecipientAddress,
 };
-
-/// Pick the preferred selection out of the candidates produced by the
-/// coin-selection strategies: a changeless transaction first (no change
-/// output to fingerprint), then the lowest fee, then the greedy fallback.
-pub(crate) fn pick_default_selection(
-    mut selections: Vec<spdk_wallet::client::InputSelection>,
-) -> Result<spdk_wallet::client::InputSelection> {
-    for preferred in [Strategy::Changeless, Strategy::LowestFee, Strategy::Greedy] {
-        if let Some(pos) = selections.iter().position(|s| s.strategy == preferred) {
-            return Ok(selections.swap_remove(pos));
-        }
-    }
-    selections
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::Error::msg("no successful coin selection"))
-}
 
 pub fn select_utxos_to_spend(
     owned_outputs: Vec<OwnedOutput>,

--- a/rust/src/api/wallet/transaction.rs
+++ b/rust/src/api/wallet/transaction.rs
@@ -1,18 +1,52 @@
 use crate::api::structs::network::Network;
-use crate::api::structs::owned_output::OwnedOutput;
+use crate::api::structs::owned_output::{OwnedOutput, WalletUtxo};
 use crate::api::structs::recipient::Recipient;
 use crate::api::structs::unsigned_transaction::SilentPaymentUnsignedTransaction;
 
 use anyhow::Result;
 use bip39::rand::{thread_rng, RngCore};
 use spdk_wallet::backend_blindbit_v1::BlindbitClient;
-use spdk_wallet::bitcoin::secp256k1::Scalar;
-use spdk_wallet::bitcoin::ScriptBuf;
-use spdk_wallet::bitcoin::{consensus::serialize, hex::DisplayHex, OutPoint};
-use spdk_wallet::client::{FeeRate, RecipientAddress, SpClient};
-use spdk_wallet::updater::DiscoveredOutput;
+use spdk_wallet::bitcoin::{consensus::serialize, hex::DisplayHex};
+use spdk_wallet::client::{
+    propose_coin_selections, propose_drain_selection, FeeRate, RecipientAddress, SpClient, Strategy,
+};
 
 use super::SpWallet;
+
+/// We currently always create a single change output.
+const N_CHANGE_OUTPUTS: usize = 1;
+
+/// Pick the preferred selection out of the candidates produced by the
+/// coin-selection strategies: a changeless transaction first (no change
+/// output to fingerprint), then the lowest fee, then the greedy fallback.
+fn pick_default_selection(
+    mut selections: Vec<spdk_wallet::client::InputSelection>,
+) -> Result<spdk_wallet::client::InputSelection> {
+    for preferred in [Strategy::Changeless, Strategy::LowestFee, Strategy::Greedy] {
+        if let Some(pos) = selections.iter().position(|s| s.strategy == preferred) {
+            return Ok(selections.swap_remove(pos));
+        }
+    }
+    selections
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::Error::msg("no successful coin selection"))
+}
+
+fn to_utxos_and_recipients(
+    owned_outputs: Vec<OwnedOutput>,
+    api_recipients: Vec<Recipient>,
+) -> Result<(Vec<WalletUtxo>, Vec<spdk_wallet::client::Recipient>)> {
+    let available_utxos = owned_outputs
+        .into_iter()
+        .map(|o| o.try_into_utxo())
+        .collect::<Result<Vec<_>>>()?;
+    let recipients = api_recipients
+        .into_iter()
+        .map(|r| r.try_into())
+        .collect::<Result<Vec<spdk_wallet::client::Recipient>>>()?;
+    Ok((available_utxos, recipients))
+}
 
 impl SpWallet {
     #[flutter_rust_bridge::frb(sync)]
@@ -23,32 +57,20 @@ impl SpWallet {
         feerate: f32,
         network: Network,
     ) -> Result<SilentPaymentUnsignedTransaction> {
-        let client = &self.client;
-        let available_utxos: Result<Vec<(OutPoint, DiscoveredOutput)>> = owned_outputs
-            .into_iter()
-            .map(|output| {
-                let outpoint = output.outpoint.into();
-                let label = match output.label {
-                    Some(l) => Some(Scalar::from_be_bytes(l)?.into()),
-                    None => None,
-                };
-                let output = DiscoveredOutput {
-                    tweak: Scalar::from_be_bytes(output.tweak)?,
-                    value: output.amount.into(),
-                    script_pubkey: ScriptBuf::from_bytes(output.script),
-                    label,
-                };
-                Ok((outpoint, output))
-            })
-            .collect();
-        let recipients: Vec<spdk_wallet::client::Recipient> = api_recipients
-            .into_iter()
-            .map(|r| r.try_into().unwrap())
-            .collect();
-        let res = client.create_new_transaction(
-            available_utxos?,
-            recipients,
+        let (available_utxos, recipients) = to_utxos_and_recipients(owned_outputs, api_recipients)?;
+
+        let selections = propose_coin_selections(
+            &available_utxos,
+            &recipients,
             FeeRate::from_sat_per_vb(feerate),
+            N_CHANGE_OUTPUTS,
+        )?;
+        let selection = pick_default_selection(selections)?;
+
+        let res = self.client.create_transaction_from_selection(
+            &available_utxos,
+            recipients,
+            selection,
             network.into(),
         )?;
 
@@ -63,30 +85,29 @@ impl SpWallet {
         feerate: f32,
         network: Network,
     ) -> Result<SilentPaymentUnsignedTransaction> {
-        let client = &self.client;
-        let available_utxos: Result<Vec<(OutPoint, DiscoveredOutput)>> = owned_outputs
+        let available_utxos = owned_outputs
             .into_iter()
-            .map(|output| {
-                let outpoint = output.outpoint.into();
-                let label = match output.label {
-                    Some(l) => Some(Scalar::from_be_bytes(l)?.into()),
-                    None => None,
-                };
-                let output = DiscoveredOutput {
-                    tweak: Scalar::from_be_bytes(output.tweak)?,
-                    value: output.amount.into(),
-                    script_pubkey: ScriptBuf::from_bytes(output.script),
-                    label,
-                };
-                Ok((outpoint, output))
-            })
-            .collect();
+            .map(|o| o.try_into_utxo())
+            .collect::<Result<Vec<_>>>()?;
 
         let recipient_address: RecipientAddress = RecipientAddress::try_from(wipe_address)?;
-        let res = client.create_drain_transaction(
-            available_utxos?,
-            recipient_address,
+        let selection = propose_drain_selection(
+            &available_utxos,
+            &recipient_address,
             FeeRate::from_sat_per_vb(feerate),
+        )?;
+
+        // The drain amount is only known after fee estimation: it is whatever
+        // is left after paying the fee for spending all UTXOs.
+        let recipients = vec![spdk_wallet::client::Recipient {
+            address: recipient_address,
+            amount: selection.sent,
+        }];
+
+        let res = self.client.create_transaction_from_selection(
+            &available_utxos,
+            recipients,
+            selection,
             network.into(),
         )?;
 

--- a/rust/src/api/wallet/transaction.rs
+++ b/rust/src/api/wallet/transaction.rs
@@ -1,3 +1,4 @@
+use crate::api::structs::input_selection::InputSelection;
 use crate::api::structs::network::Network;
 use crate::api::structs::owned_output::{OwnedOutput, WalletUtxo};
 use crate::api::structs::recipient::Recipient;
@@ -8,30 +9,14 @@ use bip39::rand::{thread_rng, RngCore};
 use spdk_wallet::backend_blindbit_v1::BlindbitClient;
 use spdk_wallet::bitcoin::{consensus::serialize, hex::DisplayHex};
 use spdk_wallet::client::{
-    propose_coin_selections, propose_drain_selection, FeeRate, RecipientAddress, SpClient, Strategy,
+    propose_coin_selections, propose_drain_selection, FeeRate, RecipientAddress, SpClient,
 };
 
+use super::coin_selection::pick_default_selection;
 use super::SpWallet;
 
 /// We currently always create a single change output.
 const N_CHANGE_OUTPUTS: usize = 1;
-
-/// Pick the preferred selection out of the candidates produced by the
-/// coin-selection strategies: a changeless transaction first (no change
-/// output to fingerprint), then the lowest fee, then the greedy fallback.
-fn pick_default_selection(
-    mut selections: Vec<spdk_wallet::client::InputSelection>,
-) -> Result<spdk_wallet::client::InputSelection> {
-    for preferred in [Strategy::Changeless, Strategy::LowestFee, Strategy::Greedy] {
-        if let Some(pos) = selections.iter().position(|s| s.strategy == preferred) {
-            return Ok(selections.swap_remove(pos));
-        }
-    }
-    selections
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::Error::msg("no successful coin selection"))
-}
 
 fn to_utxos_and_recipients(
     owned_outputs: Vec<OwnedOutput>,
@@ -108,6 +93,26 @@ impl SpWallet {
             &available_utxos,
             recipients,
             selection,
+            network.into(),
+        )?;
+
+        Ok(res.into())
+    }
+
+    #[flutter_rust_bridge::frb(sync)]
+    pub fn create_transaction_from_selection(
+        &self,
+        owned_outputs: Vec<OwnedOutput>,
+        api_recipients: Vec<Recipient>,
+        selection: InputSelection,
+        network: Network,
+    ) -> Result<SilentPaymentUnsignedTransaction> {
+        let (available_utxos, recipients) = to_utxos_and_recipients(owned_outputs, api_recipients)?;
+
+        let res = self.client.create_transaction_from_selection(
+            &available_utxos,
+            recipients,
+            selection.into(),
             network.into(),
         )?;
 

--- a/rust/src/api/wallet/transaction.rs
+++ b/rust/src/api/wallet/transaction.rs
@@ -8,15 +8,9 @@ use anyhow::Result;
 use bip39::rand::{thread_rng, RngCore};
 use spdk_wallet::backend_blindbit_v1::BlindbitClient;
 use spdk_wallet::bitcoin::{consensus::serialize, hex::DisplayHex};
-use spdk_wallet::client::{
-    propose_coin_selections, propose_drain_selection, FeeRate, RecipientAddress, SpClient,
-};
+use spdk_wallet::client::SpClient;
 
-use super::coin_selection::pick_default_selection;
 use super::SpWallet;
-
-/// We currently always create a single change output.
-const N_CHANGE_OUTPUTS: usize = 1;
 
 fn to_utxos_and_recipients(
     owned_outputs: Vec<OwnedOutput>,
@@ -34,71 +28,6 @@ fn to_utxos_and_recipients(
 }
 
 impl SpWallet {
-    #[flutter_rust_bridge::frb(sync)]
-    pub fn create_new_transaction(
-        &self,
-        owned_outputs: Vec<OwnedOutput>,
-        api_recipients: Vec<Recipient>,
-        feerate: f32,
-        network: Network,
-    ) -> Result<SilentPaymentUnsignedTransaction> {
-        let (available_utxos, recipients) = to_utxos_and_recipients(owned_outputs, api_recipients)?;
-
-        let selections = propose_coin_selections(
-            &available_utxos,
-            &recipients,
-            FeeRate::from_sat_per_vb(feerate),
-            N_CHANGE_OUTPUTS,
-        )?;
-        let selection = pick_default_selection(selections)?;
-
-        let res = self.client.create_transaction_from_selection(
-            &available_utxos,
-            recipients,
-            selection,
-            network.into(),
-        )?;
-
-        Ok(res.into())
-    }
-
-    #[flutter_rust_bridge::frb(sync)]
-    pub fn create_drain_transaction(
-        &self,
-        owned_outputs: Vec<OwnedOutput>,
-        wipe_address: String,
-        feerate: f32,
-        network: Network,
-    ) -> Result<SilentPaymentUnsignedTransaction> {
-        let available_utxos = owned_outputs
-            .into_iter()
-            .map(|o| o.try_into_utxo())
-            .collect::<Result<Vec<_>>>()?;
-
-        let recipient_address: RecipientAddress = RecipientAddress::try_from(wipe_address)?;
-        let selection = propose_drain_selection(
-            &available_utxos,
-            &recipient_address,
-            FeeRate::from_sat_per_vb(feerate),
-        )?;
-
-        // The drain amount is only known after fee estimation: it is whatever
-        // is left after paying the fee for spending all UTXOs.
-        let recipients = vec![spdk_wallet::client::Recipient {
-            address: recipient_address,
-            amount: selection.sent,
-        }];
-
-        let res = self.client.create_transaction_from_selection(
-            &available_utxos,
-            recipients,
-            selection,
-            network.into(),
-        )?;
-
-        Ok(res.into())
-    }
-
     #[flutter_rust_bridge::frb(sync)]
     pub fn create_transaction_from_selection(
         &self,

--- a/test/utils/coin_selection_test.dart
+++ b/test/utils/coin_selection_test.dart
@@ -1,0 +1,70 @@
+import 'package:danawallet/generated/rust/api/structs/amount.dart';
+import 'package:danawallet/generated/rust/api/structs/input_selection.dart';
+import 'package:danawallet/utils/coin_selection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+InputSelection selection({
+  required CoinSelectionStrategy strategy,
+  int changeSats = 10000,
+  int feeSats = 200,
+  double actualFeeRate = 1.0,
+}) {
+  return InputSelection(
+    selectedUtxos: const [],
+    sent: Amount(field0: BigInt.from(50000)),
+    nSentOutputs: BigInt.one,
+    change: Amount(field0: BigInt.from(changeSats)),
+    nChangeOutputs: BigInt.from(changeSats > 0 ? 1 : 0),
+    fee: Amount(field0: BigInt.from(feeSats)),
+    actualFeeRate: actualFeeRate,
+    strategy: strategy,
+  );
+}
+
+void main() {
+  group('pickDefaultSelection', () {
+    final changeless =
+        selection(strategy: CoinSelectionStrategy.changeless, changeSats: 0);
+    final lowestFee = selection(strategy: CoinSelectionStrategy.lowestFee);
+    final feeRateCap = selection(strategy: CoinSelectionStrategy.feeRateCap);
+    final greedy = selection(strategy: CoinSelectionStrategy.greedy);
+    final all = [greedy, feeRateCap, lowestFee, changeless];
+
+    test('default mode prefers changeless', () {
+      expect(pickDefaultSelection(all), changeless);
+    });
+
+    test('default mode prefers lowestFee without changeless', () {
+      expect(pickDefaultSelection([greedy, feeRateCap, lowestFee]), lowestFee);
+    });
+
+    test('default mode prefers feeRateCap over greedy', () {
+      expect(pickDefaultSelection([greedy, feeRateCap]), feeRateCap);
+    });
+
+    test('forceFeeRate prefers feeRateCap over everything else', () {
+      expect(pickDefaultSelection(all, forceFeeRate: true), feeRateCap);
+    });
+
+    test('forceFeeRate prefers lowestFee when no exact-rate selection', () {
+      expect(pickDefaultSelection([changeless, greedy, lowestFee], forceFeeRate: true),
+          lowestFee);
+    });
+
+    test('forceFeeRate keeps changeless as last resort', () {
+      expect(pickDefaultSelection([changeless, greedy], forceFeeRate: true),
+          greedy);
+      expect(pickDefaultSelection([changeless], forceFeeRate: true),
+          changeless);
+    });
+
+    test('falls back to the first selection for unknown strategies', () {
+      final drain = selection(strategy: CoinSelectionStrategy.drain, changeSats: 0);
+      expect(pickDefaultSelection([drain]), drain);
+    });
+
+    test('throws on empty selections', () {
+      expect(() => pickDefaultSelection([]), throwsException);
+    });
+  });
+}


### PR DESCRIPTION
We used to not really use the feature of the `coin_select` crate, basically defaulting to a greedy strategy. This PR makes the necessary changes to actually have multiple strategies available.